### PR TITLE
PHP errors on older php

### DIFF
--- a/CarbonForms/EmailNotification.php
+++ b/CarbonForms/EmailNotification.php
@@ -8,24 +8,7 @@ class EmailNotification {
 	/**
 	 * Settings
 	 */
-	private $base_settings = [
-		'recipients'  => [],
-		'from'        => '',
-		'from_name'   => '',
-		'subject'     => '',
-
-		'template'    => __DIR__ . '/../email-templates/form.php',
-
-		'smtp_config' => [
-			'enable'     => false,
-			'host'       => '',
-			'port'       => '',
-			'username'   => '',
-			'password'   => '',
-			'encryption' => '',
-
-		],
-	];
+	private $base_settings;
 
 	/**
 	 * Path to the template file
@@ -44,6 +27,25 @@ class EmailNotification {
 	public $error;
 
 	function __construct($settings=[]) {
+		$this->base_settings = [
+			'recipients'  => [],
+			'from'        => '',
+			'from_name'   => '',
+			'subject'     => '',
+
+			'template'    => __DIR__ . '/../email-templates/form.php',
+
+			'smtp_config' => [
+				'enable'     => false,
+				'host'       => '',
+				'port'       => '',
+				'username'   => '',
+				'password'   => '',
+				'encryption' => '',
+
+			],
+		];
+
 		$settings = array_merge($this->base_settings, $settings);
 
 		$mailer = new \PHPMailer();


### PR DESCRIPTION
I have experienced php parsing error around the following code:
```__DIR__ . '/../email-templates/form.php'```

The error triggered is:
```
<b>Parse error</b>:  syntax error, unexpected '.', expecting ']' in <b>/htdocs/vendor/emohamed/carbon-email-notification/CarbonForms/EmailNotification.php</b> on line <b>17</b
```

Server is on PHP Version 5.5.38.